### PR TITLE
Use the 'provided' scope that is available from the android plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,17 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:+'
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:+'
   }
 }
 
 apply plugin: 'android'
-apply plugin: 'android-apt'
 
 dependencies {
   compile 'com.github.frankiesardo:android-auto-value:+'
-  apt 'com.github.frankiesardo:android-auto-value-processor:+'
+  provided 'com.github.frankiesardo:android-auto-value-processor:+'
 }
 ```
 
-I recommend using the `android-apt` plugin so that Android Studio picks up the generated files.
 Check out the sample project for a working example.
 
 License

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ subprojects {
     }
     dependencies {
       classpath 'com.android.tools.build:gradle:0.9.+'
-      classpath 'com.neenbedankt.gradle.plugins:android-apt:1.2'
     }
   }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'android'
-apply plugin: 'android-apt'
 
 android {
   compileSdkVersion 19
@@ -15,5 +14,5 @@ android {
 
 dependencies {
   compile project(':android-auto-value')
-  apt project(':android-auto-value-processor')
+  provided project(':android-auto-value-processor')
 }


### PR DESCRIPTION
Drops the apt-plugin
