### PR TITLE
Fix Travis Build: Update buildToolsVersion to 22.0.1

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ android {
         abortOnError false
     }
     compileSdkVersion 22
-    buildToolsVersion "22.0.0"   
+    buildToolsVersion "22.0.1"   
 }
 
 dependencies {


### PR DESCRIPTION
Update buildToolsVersion to 22.0.1 to match the version in .travis.yml

The build was failing because .travis.yml defines buildToolsVersion 22.0.1 and the sample uses 22.0.0