### PR TITLE
Make generated constructor package-private

### DIFF
--- a/src/auto_parcel/extension.clj
+++ b/src/auto_parcel/extension.clj
@@ -36,7 +36,7 @@ final class {{& class-name}} extends {{& class-to-extend}} {
     {{/props}}
   }
 
-  private {{& class-name}}(Parcel in) {
+  {{& class-name}}(Parcel in) {
     this(
       {{#props}}
       ({{& cast-type}}) in.readValue(CL){{^last?}},{{/last?}}


### PR DESCRIPTION
This gets rid of a synthetic accessor method reducing the method count.
See http://blog.bradcampbell.nz/a-comparison-of-parcelable-boilerplate-libraries/